### PR TITLE
Add player analytics to Analysis page

### DIFF
--- a/world_cup_26_predictions/pages/1_Analysis_Tool.py
+++ b/world_cup_26_predictions/pages/1_Analysis_Tool.py
@@ -1,78 +1,25 @@
 import streamlit as st
-import time
-import numpy as np
-import pandas as pd
-import streamlit.components.v1 as components
-import json
-import plotly.express as px
-import os
-from data_manager import (
-    load_data,
-    create_advanced_player_stats
-)
+from player_analytics.player_analytics_tab import run_analytics_tab
 
-# Logging tool, purely used for debugging
-def log_to_console(message: str) -> None:
-    js_code = f"""
-<script>
-    console.log({json.dumps(message)});
-</script>
-"""
-    components.html(js_code)
-    
-st.set_page_config(page_title="Analysis Tool", page_icon="📈")
+def main():
+    """
+    Main entry point for the World Cup Player Analytics app.
+    Sets up a tabbed interface with a Home tab, Player Analytics tab, and an About tab.
+    """
 
-st.markdown("# Analysis Tool")
-st.sidebar.header("Analysis Tool")
-st.write(
-    """This is where the analysis will take place"""
-)
+    st.set_page_config(page_title="World Cup Player Analytics", layout="wide")
+    st.title("World Cup 2026 Player Analytics")
 
-data_path = os.path.join(os.path.dirname(os.getcwd()), "world-cup-26-predictions", "world_cup_26_predictions","data")
-df = pd.read_csv(data_path + "/teams.csv")
+    # Create tabs for navigation
+    tabs = st.tabs(["Player Analytics", "Team Analytics"])
 
-countries = st.multiselect(
-        "Choose countries", list(df['team_name'])
-    )
+    with tabs[0]:
+        st.header("Player Analytics")
+        # Displays the enhanced analytics page
+        run_analytics_tab()
 
-dataframes = load_data(data_path)
-all_stats = create_advanced_player_stats(dataframes)
+    with tabs[1]:
+        st.header("Team Analytics")
 
-gender = st.multiselect(
-    "Select gender", list(("Male", "Female"))
-)
-
-# Will be refactoring this -- I know the repeated code is ugly but function > code style rn :)
-names_and_ko_goals = all_stats[['full_name', 'knockout_goals', 'female']]
-if not gender:
-    filtered_df = names_and_ko_goals.nlargest(10, 'knockout_goals')
-    figure = px.bar(filtered_df, x='full_name', y='knockout_goals', title='Top 10 scorers in World Cup history')
-    st.plotly_chart(figure)
-else:
-    if (gender[0] != 'Female'):
-        filtered_df = names_and_ko_goals[names_and_ko_goals['female'] == False]
-        filtered_df = filtered_df.nlargest(10, 'knockout_goals')
-        figure = px.bar(filtered_df, x='full_name', y='knockout_goals', title='Top 10 male scorers in World Cup history')
-        st.plotly_chart(figure)
-    else:
-        filtered_df = names_and_ko_goals[names_and_ko_goals['female'] == True]
-        filtered_df = filtered_df.nlargest(10, 'knockout_goals')
-        figure = px.bar(filtered_df, x='full_name', y='knockout_goals', title='Top 10 female scorers in World Cup history')
-        st.plotly_chart(figure)
-
-names_and_apps = all_stats[['full_name', 'total_appearances', 'female']]
-if not gender:
-    filtered_df = names_and_apps.nlargest(10, 'total_appearances')
-    figure2 = px.bar(filtered_df, x='full_name', y='total_appearances', title='Top 10 players with most appearances in World Cup history')
-    st.plotly_chart(figure2)
-else:
-    if (gender[0] != 'Female'):
-        filtered_df = names_and_apps[names_and_apps['female'] == False]
-        filtered_df = filtered_df.nlargest(10, 'total_appearances')
-        figure2 = px.bar(filtered_df, x='full_name', y='total_appearances', title='Top 10 male players with most appearances in World Cup history')
-        st.plotly_chart(figure2)
-    else:
-        filtered_df = names_and_apps[names_and_apps['female'] == True]
-        filtered_df = filtered_df.nlargest(10, 'total_appearances')
-        figure2 = px.bar(filtered_df, x='full_name', y='total_appearances', title='Top 10 female players with most appearances in World Cup history')
-        st.plotly_chart(figure2)
+if __name__ == "__main__":
+    main()

--- a/world_cup_26_predictions/player_analytics/player_analytics.py
+++ b/world_cup_26_predictions/player_analytics/player_analytics.py
@@ -1,0 +1,362 @@
+import plotly.express as px
+import plotly.graph_objects as go
+import pandas as pd
+import numpy as np
+import plotly.io as pio
+
+# Use a more colorful Plotly template
+pio.templates.default = "plotly"
+
+#color sequence
+DEFAULT_COLOR_SEQ = px.colors.qualitative.Bold
+
+
+def plot_top_scorers(player_stats, n=10, color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top scorers by total_goals."""
+    if player_stats.empty:
+        return None
+
+    df_top = player_stats.nlargest(n, 'total_goals').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='total_goals',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} All-Time Scorers"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Total Goals")
+    return fig
+
+
+def plot_top_knockout_scorers(player_stats, n=10, color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top scorers by knockout_goals."""
+    if player_stats.empty:
+        return None
+
+    df_top = player_stats.nlargest(n, 'knockout_goals').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='knockout_goals',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Knockout-Stage Scorers"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Knockout Goals")
+    return fig
+
+
+def plot_goals_per_appearance(player_stats, min_appearances=10, n=10,
+                              color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top players by goals_per_appearance (>= min_appearances)."""
+    df_eligible = player_stats[player_stats['total_appearances'] >= min_appearances]
+    if df_eligible.empty:
+        return None
+
+    df_top = df_eligible.nlargest(n, 'goals_per_appearance').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='goals_per_appearance',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Goals/App (Min {min_appearances} Apps)"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Goals/App")
+    return fig
+
+
+def plot_most_awarded_players(player_stats, n=10, color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top players by total_awards."""
+    df_top = player_stats.nlargest(n, 'total_awards').copy()
+    if df_top.empty:
+        return None
+
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='total_awards',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Most Awarded Players"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Awards")
+    return fig
+
+
+def plot_best_penalty_conversion(player_stats, min_attempts=1, n=10,
+                                 color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top players by penalty_conversion (>= min_attempts)."""
+    df_eligible = player_stats[player_stats['penalty_attempts'] >= min_attempts]
+    if df_eligible.empty:
+        return None
+
+    df_top = df_eligible.nlargest(n, 'penalty_conversion').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='penalty_conversion',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Penalty Conversion (Min {min_attempts} Attempts)"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Conversion Rate")
+    return fig
+
+
+def plot_highest_card_rate(player_stats, min_appearances=10, n=10,
+                           color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of players with highest cards_per_appearance (>= min_appearances)."""
+    df_eligible = player_stats[player_stats['total_appearances'] >= min_appearances]
+    if df_eligible.empty:
+        return None
+
+    df_top = df_eligible.nlargest(n, 'cards_per_appearance').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='cards_per_appearance',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Cards/App (Min {min_appearances} Apps)"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="Cards/App")
+    return fig
+
+
+def plot_substitution_patterns(player_stats, n=10, color_by=None, hover_cols=None, color_seq=None):
+    """
+    Returns two figures (fig_on, fig_off):
+      - top 'n' players by times_subbed_on
+      - top 'n' players by times_subbed_off
+    """
+    if player_stats.empty:
+        return None, None
+
+    df_on = player_stats.nlargest(n, 'times_subbed_on').copy()
+    fig_on = px.bar(
+        df_on,
+        x='full_name',
+        y='times_subbed_on',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} - Times Subbed On"
+    )
+    fig_on.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="# Subbed On")
+
+    df_off = player_stats.nlargest(n, 'times_subbed_off').copy()
+    fig_off = px.bar(
+        df_off,
+        x='full_name',
+        y='times_subbed_off',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} - Times Subbed Off"
+    )
+    fig_off.update_layout(title_x=0.5, xaxis_title="Player", yaxis_title="# Subbed Off")
+
+    return fig_on, fig_off
+
+
+def plot_position_appearances(player_stats, position_bool_column='goal_keeper',
+                              position_label='Goalkeepers',
+                              n=10,
+                              color_by=None, hover_cols=None, color_seq=None):
+    """Bar chart of top 'n' players in a particular position by total_appearances."""
+    df_pos = player_stats[player_stats[position_bool_column] == True]
+    if df_pos.empty:
+        return None
+
+    df_top = df_pos.nlargest(n, 'total_appearances').copy()
+    fig = px.bar(
+        df_top,
+        x='full_name',
+        y='total_appearances',
+        color=color_by,
+        hover_data=hover_cols,
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} {position_label} by Appearances"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title=position_label, yaxis_title="Appearances")
+    return fig
+
+
+def compare_players(player_stats, selected_players):
+    """
+    Returns a DataFrame comparing the selected players on key stats,
+    sorted by total_goals desc.
+    """
+    if player_stats.empty or not selected_players:
+        return pd.DataFrame()
+
+    subset = player_stats[player_stats['full_name'].isin(selected_players)]
+    if subset.empty:
+        return pd.DataFrame()
+
+    subset = subset.sort_values('total_goals', ascending=False)
+    columns_to_show = [
+        'player_id','full_name','continent',
+        'total_appearances','total_goals','knockout_goals','goals_per_appearance',
+        'total_cards','cards_per_appearance',
+        'penalty_attempts','penalty_converted','penalty_conversion',
+        'total_awards','times_subbed_on','times_subbed_off',
+        'subbed_on_goals','clutch_goals'
+    ]
+    subset = subset[columns_to_show].reset_index(drop=True)
+    return subset
+
+
+def plot_compare_players_side_by_side(player_stats, selected_players):
+    """
+    Creates a grouped bar chart to compare multiple players across several key metrics side-by-side.
+    """
+    df = player_stats[player_stats['full_name'].isin(selected_players)].copy()
+    if df.empty:
+        return None
+
+    df = df.sort_values('total_goals', ascending=False)
+
+    stats_of_interest = {
+        'total_goals': 'Total Goals',
+        'knockout_goals': 'Knockout Goals',
+        'total_appearances': 'Appearances',
+        'penalty_conversion': 'Penalty Conv.',
+        'total_awards': 'Awards'
+    }
+
+    records = []
+    for _, row in df.iterrows():
+        for stat_col, stat_label in stats_of_interest.items():
+            records.append({
+                'Player': row['full_name'],
+                'Statistic': stat_label,
+                'Value': row[stat_col]
+            })
+    long_df = pd.DataFrame(records)
+
+    fig = px.bar(
+        long_df,
+        x='Statistic',
+        y='Value',
+        color='Player',
+        barmode='group',
+        title="Player Comparison (Side-by-Side)",
+        color_discrete_sequence=px.colors.qualitative.Bold
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="", yaxis_title="Value")
+    return fig
+
+
+def plot_comparison_radar(player_stats, selected_players):
+    """
+    Radar chart comparing up to 5 players on 6 advanced metrics:
+      - goals_per_appearance
+      - knockout_goals (scaled log)
+      - discipline_score (1/(1+cards_per_appearance))
+      - penalty_conversion
+      - total_awards (scaled log)
+      - subbed_on_goals (scaled log)
+    """
+    df = player_stats[player_stats['full_name'].isin(selected_players)].copy()
+    if df.empty:
+        return None
+
+    # Limit to 5
+    df = df.head(5)
+
+    df['knockout_scaled'] = np.log1p(df['knockout_goals']) * 5
+    df['discipline_score'] = 1 / (1 + df['cards_per_appearance'])
+    df['awards_scaled'] = np.log1p(df['total_awards']) * 5
+    df['subbed_on_scaled'] = np.log1p(df['subbed_on_goals']) * 5
+
+    categories = [
+        "goals_per_appearance",
+        "knockout_scaled",
+        "discipline_score",
+        "penalty_conversion",
+        "awards_scaled",
+        "subbed_on_scaled"
+    ]
+    labels = ["Goals/App", "Knockout", "Discipline", "Pen. Conv.", "Awards", "Subbed-On"]
+
+    fig = go.Figure()
+    for _, row in df.iterrows():
+        values = [
+            row["goals_per_appearance"],
+            row["knockout_scaled"],
+            row["discipline_score"],
+            row["penalty_conversion"],
+            row["awards_scaled"],
+            row["subbed_on_scaled"]
+        ]
+        fig.add_trace(go.Scatterpolar(r=values, theta=labels, fill='toself', name=row['full_name']))
+
+    fig.update_layout(
+        title="Player Comparison Radar",
+        title_x=0.5,
+        polar=dict(radialaxis=dict(visible=True)),
+        showlegend=True
+    )
+    return fig
+
+
+def plot_top_clutch_scorers(player_stats, n=5, color_seq=None):
+    """
+    Horizontal bar chart of the top 'n' clutch scorers (goals in 75+ minute).
+    """
+    if player_stats.empty or 'clutch_goals' not in player_stats.columns:
+        return None
+
+    df_top = player_stats.nlargest(n, 'clutch_goals').copy()
+    if df_top.empty:
+        return None
+
+    fig = px.bar(
+        df_top,
+        x='clutch_goals',
+        y='full_name',
+        orientation='h',
+        text='clutch_goals',
+        color='full_name',
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Clutch Scorers (75+ min)"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Clutch Goals", yaxis_title="Player", showlegend=False)
+    fig.update_traces(textposition='inside')
+    return fig
+
+
+def plot_top_impact_players(player_stats, n=5, color_seq=None):
+    """
+    Horizontal bar chart of the top 'n' impact players 
+    (goals scored after being subbed on).
+    """
+    if player_stats.empty or 'subbed_on_goals' not in player_stats.columns:
+        return None
+
+    df_top = player_stats.nlargest(n, 'subbed_on_goals').copy()
+    if df_top.empty:
+        return None
+
+    fig = px.bar(
+        df_top,
+        x='subbed_on_goals',
+        y='full_name',
+        orientation='h',
+        text='subbed_on_goals',
+        color='full_name',
+        color_discrete_sequence=color_seq or DEFAULT_COLOR_SEQ,
+        title=f"Top {n} Impact Players (Subbed-on Goals)"
+    )
+    fig.update_layout(title_x=0.5, xaxis_title="Goals After Sub", yaxis_title="Player", showlegend=False)
+    fig.update_traces(textposition='inside')
+    return fig

--- a/world_cup_26_predictions/player_analytics/player_analytics_tab.py
+++ b/world_cup_26_predictions/player_analytics/player_analytics_tab.py
@@ -1,0 +1,302 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+import plotly.graph_objects as go
+
+# From our modules
+from data_manager import load_data, create_advanced_player_stats, filter_players
+import player_analytics.player_analytics as visuals
+
+
+@st.cache_data
+def get_player_stats():
+    """
+    Caches the loading and creation of advanced player stats
+    to avoid re-processing on every user interaction.
+    """
+    dfs = load_data()
+    return create_advanced_player_stats(dfs)
+
+
+def run_analytics_tab():
+    """
+    Displays a Player Analytics page with:
+      - Filters (gender, continent, position)
+      - Key Leaderboards
+      - Extra analytics
+      - Two-Player Comparison (Side-by-side metrics + Radar)
+      - Misc. Fun/Trivia
+    """
+
+    # --- HELPER: Dynamic Default Players ---
+    def get_default_two_players(gender, all_names):
+        """
+        Returns up to 2 default player names that exist in 'all_names'.
+        If the candidate defaults aren't available, fallback to
+        the first two players in 'all_names' if possible.
+        """
+        # Define some candidate defaults based on gender
+        if gender == "Women":
+            candidate = ["Marta", "Megan Rapinoe", "Alex Morgan"]
+        elif gender == "Men":
+            candidate = ["Lionel Messi", "Cristiano Ronaldo", "Pelé"]
+        else:
+            candidate = ["Lionel Messi", "Cristiano Ronaldo"]
+
+        # Intersect with available
+        intersected = [p for p in candidate if p in all_names]
+        if len(intersected) >= 2:
+            return intersected[:2]
+        elif len(all_names) >= 2:
+            # Fallback to first two from the dataset
+            return all_names[:2]
+        elif len(all_names) == 1:
+            return all_names
+        else:
+            return []  # no available players
+
+    # ----------------------------------------------
+    # 1) LOAD DATA
+    # ----------------------------------------------
+    st.header("Player Analytics")
+    player_stats = get_player_stats()
+
+    # ----------------------------------------------
+    # 2) FILTERS
+    # ----------------------------------------------
+    with st.expander("Filters", expanded=False):
+        gender_option = st.selectbox("Filter by Gender:", ["All", "Men", "Women"], index=0)
+
+        # We gather continents from the entire dataset
+        continent_list = ["All"] + sorted(player_stats['continent'].unique().tolist())
+        continent_option = st.selectbox("Filter by Continent:", continent_list, index=0)
+
+        position_option = st.selectbox(
+            "Filter by Position:",
+            ["All", "Goalkeeper", "Defender", "Midfielder", "Forward"],
+            index=0
+        )
+
+    filtered_stats = filter_players(player_stats, gender_option, continent_option, position_option)
+    if filtered_stats.empty:
+        st.warning("No data found for the selected filters.")
+        return
+
+    # How many players to show in the various leaderboards
+    top_n = st.slider("Number of Players in Top Lists:", 5, 30, 10)
+
+    # ----------------------------------------------
+    # 3) KEY LEADERBOARDS & METRICS
+    # ----------------------------------------------
+    st.subheader("Key Leaderboards & Metrics")
+
+    col_left, col_right = st.columns(2)
+    with col_left:
+        # Top Scorers
+        fig_scorers = visuals.plot_top_scorers(
+            filtered_stats, n=top_n, color_by='continent',
+            hover_cols=["primary_confederation", "total_appearances", "primary_team_name"]
+        )
+        if fig_scorers:
+            st.plotly_chart(fig_scorers, use_container_width=True)
+
+        # Top Knockout
+        fig_knockout = visuals.plot_top_knockout_scorers(
+            filtered_stats, n=top_n, color_by='continent',
+            hover_cols=["primary_confederation","total_appearances"]
+        )
+        if fig_knockout:
+            st.plotly_chart(fig_knockout, use_container_width=True)
+
+    with col_right:
+        # Goals per Appearance
+        fig_gpa = visuals.plot_goals_per_appearance(
+            filtered_stats, min_appearances=10, n=top_n,
+            color_by='continent',
+            hover_cols=["primary_confederation","total_goals","total_appearances"]
+        )
+        if fig_gpa:
+            st.plotly_chart(fig_gpa, use_container_width=True)
+
+        # Most Awarded
+        fig_awards = visuals.plot_most_awarded_players(
+            filtered_stats, n=top_n, color_by='continent',
+            hover_cols=["primary_confederation", "total_awards"]
+        )
+        if fig_awards:
+            st.plotly_chart(fig_awards, use_container_width=True)
+
+    # ----------------------------------------------
+    # 4) ADDITIONAL LEADERBOARDS & POSITION STATS
+    # ----------------------------------------------
+    with st.expander("Show More Analytics", expanded=False):
+        col_ex1, col_ex2 = st.columns(2)
+
+        with col_ex1:
+            # Penalty Conversion
+            fig_pen = visuals.plot_best_penalty_conversion(
+                filtered_stats, min_attempts=3, n=top_n,
+                color_by='continent',
+                hover_cols=["primary_confederation","penalty_attempts","penalty_converted"]
+            )
+            if fig_pen:
+                st.plotly_chart(fig_pen, use_container_width=True)
+
+            # Highest Card Rate
+            fig_cards = visuals.plot_highest_card_rate(
+                filtered_stats, min_appearances=10, n=top_n,
+                color_by='continent',
+                hover_cols=["primary_confederation","total_cards","total_appearances"]
+            )
+            if fig_cards:
+                st.plotly_chart(fig_cards, use_container_width=True)
+
+        with col_ex2:
+            # Substitution Patterns
+            fig_on, fig_off = visuals.plot_substitution_patterns(
+                filtered_stats, n=top_n, color_by='continent'
+            )
+            if fig_on:
+                st.plotly_chart(fig_on, use_container_width=True)
+            if fig_off:
+                st.plotly_chart(fig_off, use_container_width=True)
+
+        st.subheader("Position-Specific Leaderboards")
+        cp1, cp2 = st.columns(2)
+        with cp1:
+            fig_gk = visuals.plot_position_appearances(filtered_stats,
+                        position_bool_column='goal_keeper',
+                        position_label='Goalkeepers', n=top_n,
+                        color_by='continent', hover_cols=["primary_confederation","total_appearances"])
+            if fig_gk:
+                st.plotly_chart(fig_gk, use_container_width=True)
+
+            fig_df = visuals.plot_position_appearances(filtered_stats,
+                        position_bool_column='defender',
+                        position_label='Defenders', n=top_n,
+                        color_by='continent', hover_cols=["primary_confederation","total_appearances"])
+            if fig_df:
+                st.plotly_chart(fig_df, use_container_width=True)
+
+        with cp2:
+            fig_mf = visuals.plot_position_appearances(filtered_stats,
+                        position_bool_column='midfielder',
+                        position_label='Midfielders', n=top_n,
+                        color_by='continent', hover_cols=["primary_confederation","total_appearances"])
+            if fig_mf:
+                st.plotly_chart(fig_mf, use_container_width=True)
+
+            fig_fw = visuals.plot_position_appearances(filtered_stats,
+                        position_bool_column='forward',
+                        position_label='Forwards', n=top_n,
+                        color_by='continent', hover_cols=["primary_confederation","total_appearances"])
+            if fig_fw:
+                st.plotly_chart(fig_fw, use_container_width=True)
+
+    # ----------------------------------------------
+    # 5) TWO-PLAYER COMPARISON
+    # ----------------------------------------------
+    st.markdown("---")
+    st.subheader("Two-Player Comparison")
+
+    # Create a dynamic default for the 2 players, based on the filtered list
+    all_names = sorted(filtered_stats['full_name'].unique().tolist())
+    default_two = get_default_two_players(gender_option, all_names)
+
+    selected_two = st.multiselect(
+        "Select Exactly 2 Players",
+        all_names,
+        default=default_two,
+        max_selections=2
+    )
+
+    if len(selected_two) < 2:
+        # If user has not chosen 2 players, show info
+        st.info("Please select exactly 2 players.")
+    else:
+        # Now we have 2 players selected
+        comparison_df = visuals.compare_players(filtered_stats, selected_two)
+        if comparison_df.empty or len(comparison_df) < 2:
+            st.warning("No data or insufficient data to compare these players.")
+        else:
+            # 3-column layout: left, center, right
+            col_p1, col_radar, col_p2 = st.columns([2,3,2])
+
+            # We'll show 5 core stats
+            p1 = comparison_df.iloc[0]
+            p2 = comparison_df.iloc[1]
+
+            with col_p1:
+                st.markdown(f"<h3 style='text-align:center'>{p1['full_name']}</h3>", unsafe_allow_html=True)
+                st.metric("Appearances", f"{int(p1['total_appearances'])}")
+                st.metric("Total Goals", f"{int(p1['total_goals'])}")
+                st.metric("Knockout Goals", f"{int(p1['knockout_goals'])}")
+                st.metric("Total Cards", f"{int(p1['total_cards'])}")
+                st.metric("Total Awards", f"{int(p1['total_awards'])}")
+
+            with col_p2:
+                st.markdown(f"<h3 style='text-align:center'>{p2['full_name']}</h3>", unsafe_allow_html=True)
+                st.metric("Appearances", f"{int(p2['total_appearances'])}")
+                st.metric("Total Goals", f"{int(p2['total_goals'])}")
+                st.metric("Knockout Goals", f"{int(p2['knockout_goals'])}")
+                st.metric("Total Cards", f"{int(p2['total_cards'])}")
+                st.metric("Total Awards", f"{int(p2['total_awards'])}")
+
+            # Center: radar
+            with col_radar:
+                radar_fig = visuals.plot_comparison_radar(filtered_stats, selected_two)
+                if radar_fig:
+                    st.plotly_chart(radar_fig, use_container_width=True)
+
+    # ----------------------------------------------
+    # 6) CLUTCH & IMPACT
+    # ----------------------------------------------
+    st.markdown("---")
+    st.subheader("Clutch Scorers & Impact Players")
+
+    c1, c2 = st.columns(2)
+    with c1:
+        fig_clutch = visuals.plot_top_clutch_scorers(filtered_stats, n=5)
+        if fig_clutch:
+            st.plotly_chart(fig_clutch, use_container_width=True)
+        else:
+            st.info("No data for Clutch Scorers.")
+
+    with c2:
+        fig_impact = visuals.plot_top_impact_players(filtered_stats, n=5)
+        if fig_impact:
+            st.plotly_chart(fig_impact, use_container_width=True)
+        else:
+            st.info("No data for Impact Players.")
+
+    # ----------------------------------------------
+    # 7) MEN & WOMEN TRIVIA
+    # ----------------------------------------------
+    st.markdown("---")
+    st.subheader("Men & Women World Cup Trivia")
+
+    st.subheader("Men's World Cup")
+    colA, colB, colC, colD = st.columns(4)
+    with colA:
+        st.metric("🏟️ First Edition", "1930")
+    with colB:
+        st.metric("🗓️ Total Tournaments", "22")
+    with colC:
+        st.metric("🏆 Most Titles", "Brazil (5)")
+    with colD:
+        st.metric("👑 Current Champion", "Argentina (2022)")
+
+    st.markdown("---")
+    st.subheader("Women's World Cup")
+    colW1, colW2, colW3, colW4 = st.columns(4)
+    with colW1:
+        st.metric("🏟️ First Edition", "1991")
+    with colW2:
+        st.metric("🗓️ Total Tournaments", "9")
+    with colW3:
+        st.metric("🏆 Most Titles", "USA (4)")
+    with colW4:
+        st.metric("👑 Current Champion", "Spain (2023)")
+
+    st.markdown("---")


### PR DESCRIPTION
This PR introduces a player analytics page along with a placeholder for team analytics. The modifications are implemented in the following files: `player_analytics.py`, `player_analytics_tab.py`, and `1_Analysis_Tool.py`.  

Player Analytics  
- Generates comprehensive visualizations for player analytics using Plotly.  

 Player Analytics Tab  
- Displays all visualizations and analytics tailored specifically for players. Given the number of visuals, a collapsible section has been added for users who wish to explore more detailed analytics. This section includes a player comparison feature and trivia, which may eventually be transferred to the team analytics tab.  

Analysis Tool  
- Manages the rendering of analysis tabs for both player and team metrics.  

Testing  
- Unit tests are currently pending creation.  

Next Steps  
- Please review and provide any feedback or suggestions. To test the app, navigate to the directory containing `Homepage.py` and execute the command: `streamlit run Homepage.py`.